### PR TITLE
Fix js header content type

### DIFF
--- a/js/breadcrumb.js.php
+++ b/js/breadcrumb.js.php
@@ -1,5 +1,7 @@
 <?php
 
+	header('Content-Type: application/javascript');
+
 	if(!empty($_POST)) exit; // no breadcrumb on submit form
 
 	require('../config.php');


### PR DESCRIPTION
Prevent js execution errors like : 
Refused to execute script from 'http://www.[...]/custom/breadcrumb/js/breadcrumb.js.php'' [^] because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.